### PR TITLE
Optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-.vscode/
 .cache/
-.ccls-cache/
-release/
-debug/
-debug_asan/
-debug_gprof/
+build/
 compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(rasterizer)
 
 set(EXECUTABLE_NAME rasterizer)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")
+set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
 add_subdirectory(src)
 add_subdirectory(lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(
     Context.c
     Renderer.c
     VertexBuffer.c
+    Shaders.c
     triangle.c
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ set(
 add_executable(${EXECUTABLE_NAME} ${SOURCES})
 target_include_directories(${EXECUTABLE_NAME} PUBLIC .)
 target_compile_options(${EXECUTABLE_NAME} PRIVATE
-    -Wall -Wextra -Wpedantic -Wno-unused -std=c2x -march=native
+    -Wall -Wextra -Wpedantic -Wno-unused -std=c2x -march=native -O3
 )
 
 if (ENABLE_ASAN)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,10 @@ target_compile_options(${EXECUTABLE_NAME} PRIVATE
 if (ENABLE_ASAN)
     target_link_options(${EXECUTABLE_NAME} PRIVATE -fsanitize=address)
 endif()
+if (ENABLE_UBSAN)
+    target_compile_options(${EXECUTABLE_NAME} PRIVATE -fsanitize=undefined)
+    target_link_options(${EXECUTABLE_NAME} PRIVATE -fsanitize=undefined)
+endif()
 
 if (ENABLE_GPROF)
     target_compile_options(${EXECUTABLE_NAME} PRIVATE -pg)

--- a/src/Primitive.h
+++ b/src/Primitive.h
@@ -11,6 +11,8 @@ typedef enum
     PRIMITIVE_TRIANGLE_FAN,
     PRIMITIVE_QUADS,
     PRIMITIVE_QUAD_STRIP,
-    PRIMITIVE_POLYGON
+    PRIMITIVE_POLYGON,
+
+    PRIMITIVE_ANY  // not for user
 } Primitive;
 

--- a/src/Shaders.c
+++ b/src/Shaders.c
@@ -1,0 +1,16 @@
+#include "Shaders.h"
+
+void shaderProgramSetDefaultGeometryShader(ShaderProgram* sp)
+{
+    GeometryShaderType* gs = &sp->geometryShader;
+    gs->shader = NULL;
+    gs->nBytesPerOutputVertex = sp->vertexShader.nBytesPerOutputVertex;
+    gs->nOutputAttributes = sp->vertexShader.nOutputAttributes;
+    // points to the same buffer!
+    gs->outputAttributes = sp->vertexShader.outputAttributes;
+    gs->indexOfOutputPositionAttribute = sp->vertexShader.indexOfOutputPositionAttribute;
+    gs->nOutputVertices = 0;
+    gs->inputPrimitive = PRIMITIVE_ANY;
+    gs->outputPrimitive = PRIMITIVE_ANY;
+}
+

--- a/src/Shaders.c
+++ b/src/Shaders.c
@@ -2,7 +2,7 @@
 
 void shaderProgramSetDefaultGeometryShader(ShaderProgram* sp)
 {
-    GeometryShaderType* gs = &sp->geometryShader;
+    GeometryShader* gs = &sp->geometryShader;
     gs->shader = NULL;
     gs->nBytesPerOutputVertex = sp->vertexShader.nBytesPerOutputVertex;
     gs->nOutputAttributes = sp->vertexShader.nOutputAttributes;

--- a/src/Shaders.h
+++ b/src/Shaders.h
@@ -21,6 +21,10 @@ typedef struct
     size_t indexOfOutputPositionAttribute;
 
     // Geometry shader specific
+    // If both `inputPrimitive` and `outputPrimitive` are `PRIMITIVE_ANY` 
+    // (so geometryShader was default-initialized) then `nOutputVertices`
+    // is not valid and should be set accordingly to primitive type that 
+    // is being processed
     size_t nOutputVertices;
     Primitive inputPrimitive;
     Primitive outputPrimitive;
@@ -37,4 +41,6 @@ typedef struct
     GeometryShaderType geometryShader;
     FragmentShaderType fragmentShader;
 } ShaderProgram;
+
+void shaderProgramSetDefaultGeometryShader(ShaderProgram* sp);
 

--- a/src/Shaders.h
+++ b/src/Shaders.h
@@ -1,20 +1,26 @@
 #pragma once
-#include "VertexAttribute.h"
+#include "Vertex.h"
 #include "Primitive.h"
 #include "Color/Color.h"
 
+typedef struct VSOutput VSOutput;
+typedef struct GSOutput GSOutput;
+typedef struct Interpolated Interpolated;
+
+typedef struct ShaderProgram ShaderProgram;
+
 typedef struct
 {
-    void (*shader)(const void* sp, const void* pVertex, void* pOutput);
+    void (*shader)(const ShaderProgram* sp, const Vertex* pVertex, VSOutput* pOutput);
     size_t nBytesPerOutputVertex;
     size_t nOutputAttributes;
     VertexAttribute* outputAttributes;
     size_t indexOfOutputPositionAttribute;
-} VertexShaderType;
+} VertexShader;
 
 typedef struct
 {
-    void (*shader)(const void* sp, const void* pInput, void* pOutput);
+    void (*shader)(const ShaderProgram* sp, const VSOutput* pInput, GSOutput* pOutput);
     size_t nBytesPerOutputVertex;
     size_t nOutputAttributes;
     VertexAttribute* outputAttributes;
@@ -28,19 +34,19 @@ typedef struct
     size_t nOutputVertices;
     Primitive inputPrimitive;
     Primitive outputPrimitive;
-} GeometryShaderType;
+} GeometryShader;
 
 typedef struct
 {
-    void (*shader)(const void* sp, const void* pInterpolated, Color* color);
-} FragmentShaderType;
+    void (*shader)(const ShaderProgram* sp, const Interpolated* pInterpolated, Color* color);
+} FragmentShader;
 
-typedef struct
+struct ShaderProgram
 {
-    VertexShaderType vertexShader;
-    GeometryShaderType geometryShader;
-    FragmentShaderType fragmentShader;
-} ShaderProgram;
+    VertexShader vertexShader;
+    GeometryShader geometryShader;
+    FragmentShader fragmentShader;
+};
 
 void shaderProgramSetDefaultGeometryShader(ShaderProgram* sp);
 

--- a/src/Shaders.h
+++ b/src/Shaders.h
@@ -5,7 +5,7 @@
 
 typedef struct
 {
-    void (*shader)(void* sp, void* pVertex, void* pOutput);
+    void (*shader)(const void* sp, const void* pVertex, void* pOutput);
     size_t nBytesPerOutputVertex;
     size_t nOutputAttributes;
     VertexAttribute* outputAttributes;
@@ -14,7 +14,7 @@ typedef struct
 
 typedef struct
 {
-    void (*shader)(void* sp, void* pInput, void* pOutput);
+    void (*shader)(const void* sp, const void* pInput, void* pOutput);
     size_t nBytesPerOutputVertex;
     size_t nOutputAttributes;
     VertexAttribute* outputAttributes;
@@ -32,7 +32,7 @@ typedef struct
 
 typedef struct
 {
-    void (*shader)(void* sp, void* pInterpolated, Color* color);
+    void (*shader)(const void* sp, const void* pInterpolated, Color* color);
 } FragmentShaderType;
 
 typedef struct

--- a/src/Vertex.h
+++ b/src/Vertex.h
@@ -2,6 +2,8 @@
 #include <stddef.h>
 #include "Type.h"
 
+typedef struct Vertex Vertex;
+
 typedef struct
 {
     size_t nItems;

--- a/src/VertexBuffer.c
+++ b/src/VertexBuffer.c
@@ -20,7 +20,8 @@ VertexBuffer* newVertexBuffer(
     this->data = xmalloc(nBytesData);
     memcpy(this->data, data, nBytesData);
     this->nAttributes = nAttributes;
-    this->attributes = attributes;
+    this->attributes = xmalloc(nAttributes * sizeof(VertexAttribute));
+    memcpy(this->attributes, attributes, nAttributes * sizeof(VertexAttribute));
 
     return this;
 }

--- a/src/VertexBuffer.h
+++ b/src/VertexBuffer.h
@@ -8,7 +8,7 @@ typedef struct
     size_t nBytesPerVertex;
     size_t nBytesData;
     size_t nVertices;
-    void* data;
+    Vertex* data;
     size_t nAttributes;
     VertexAttribute* attributes;
 } VertexBuffer;
@@ -23,5 +23,5 @@ void drawVertexBuffer(
     VertexBuffer* this, Primitive drawMode, size_t startIndex, size_t count, 
     ShaderProgram* shaderProgram
 );
-static void drawRawVertexBuffer(void* gsOutput, ShaderProgram* sp, Primitive primitive);
+static void drawRawVertexBuffer(GSOutput* gsOutput, ShaderProgram* sp, Primitive primitive);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,3 +1,4 @@
+#include <wchar.h>
 #define SDL_MAIN_HANDLED
 #include <assert.h>
 #include "Renderer.h"
@@ -13,20 +14,20 @@
 Context context;
 
 #pragma pack(push, 1)
-typedef struct
+struct Vertex
 {
     double position[3];
     double color[3];
-} Vertex;
+};
 #pragma pack(pop)
 
-void vertexShader(const void* shaderProgram, const void* pVertex, void* pOutput)
+void vertexShader(const ShaderProgram* shaderProgram, const Vertex* pVertex, VSOutput* pOutput)
 {
     ShaderProgram* sp = (ShaderProgram*) shaderProgram;
     memcpy(pOutput, pVertex, sp->vertexShader.nBytesPerOutputVertex);
 }
 
-void geometryShader(const void* shaderProgram, const void* pInput, void* pOutput)
+void geometryShader(const ShaderProgram* shaderProgram, const VSOutput* pInput, GSOutput* pOutput)
 {
     ShaderProgram* sp = (ShaderProgram*) shaderProgram;
 
@@ -73,7 +74,7 @@ void geometryShader(const void* shaderProgram, const void* pInput, void* pOutput
     }
 }
 
-void fragmentShader(const void* shaderProgram, const void* pInterpolated, Color* color)
+void fragmentShader(const ShaderProgram* shaderProgram, const Interpolated* pInterpolated, Color* color)
 {
     ShaderProgram* sp = (ShaderProgram*) shaderProgram;
     Vector3d colorVec = *(Vector3d*) (
@@ -88,7 +89,7 @@ void fragmentShader(const void* shaderProgram, const void* pInterpolated, Color*
     };
 }
 
-void fragmentShaderZ(const void* shaderProgram, const void* pInterpolated, Color* color)
+void fragmentShaderZ(const ShaderProgram* shaderProgram, const Interpolated* pInterpolated, Color* color)
 {
     ShaderProgram* sp = (ShaderProgram*) shaderProgram;
     double* position = (double*) ((uint8_t*) pInterpolated + sp->geometryShader.outputAttributes[
@@ -129,7 +130,7 @@ int main(int argc, char** argv)
     };
 
     VertexBuffer* vb = newVertexBuffer(
-        sizeof(Vertex), sizeof(data), data, 1, attributes
+        sizeof(Vertex), sizeof(data), data, 2, attributes
     );
 
     ShaderProgram shaderProgram = {

--- a/src/main.c
+++ b/src/main.c
@@ -20,13 +20,13 @@ typedef struct
 } Vertex;
 #pragma pack(pop)
 
-void vertexShader(void* shaderProgram, void* pVertex, void* pOutput)
+void vertexShader(const void* shaderProgram, const void* pVertex, void* pOutput)
 {
     ShaderProgram* sp = (ShaderProgram*) shaderProgram;
     memcpy(pOutput, pVertex, sp->vertexShader.nBytesPerOutputVertex);
 }
 
-void geometryShader(void* shaderProgram, void* pInput, void* pOutput)
+void geometryShader(const void* shaderProgram, const void* pInput, void* pOutput)
 {
     ShaderProgram* sp = (ShaderProgram*) shaderProgram;
 
@@ -73,7 +73,7 @@ void geometryShader(void* shaderProgram, void* pInput, void* pOutput)
     }
 }
 
-void fragmentShader(void* shaderProgram, void* pInterpolated, Color* color)
+void fragmentShader(const void* shaderProgram, const void* pInterpolated, Color* color)
 {
     ShaderProgram* sp = (ShaderProgram*) shaderProgram;
     Vector3d colorVec = *(Vector3d*) (
@@ -88,7 +88,7 @@ void fragmentShader(void* shaderProgram, void* pInterpolated, Color* color)
     };
 }
 
-void fragmentShaderZ(void* shaderProgram, void* pInterpolated, Color* color)
+void fragmentShaderZ(const void* shaderProgram, const void* pInterpolated, Color* color)
 {
     ShaderProgram* sp = (ShaderProgram*) shaderProgram;
     double* position = (double*) ((uint8_t*) pInterpolated + sp->geometryShader.outputAttributes[

--- a/src/main.c
+++ b/src/main.c
@@ -1,11 +1,14 @@
 #define SDL_MAIN_HANDLED
-#include <time.h>
+#include <assert.h>
 #include "Renderer.h"
 #include "VertexBuffer.h"
 #include "Shaders.h"
 #include "Context.h"
 #include "Type.h"
+#include "Color/Color.h"
+#include "Vector/Vector.h"
 #include "log.h"
+#include "timer.h"
 
 Context context;
 
@@ -155,11 +158,9 @@ int main(int argc, char** argv)
     shaderProgramSetDefaultGeometryShader(&shaderProgram);
 
     size_t frameCount = 0;
-    clock_t begin, end;
-    double frametimeSec;
     while (context.running)
     {
-        begin = clock();
+        TIMER_START(frametime);
 
         rendererClearBuffer(context.renderer, (Color) {0, 0, 0, 255});
         shaderProgram.fragmentShader.shader = fragmentShader;
@@ -171,11 +172,11 @@ int main(int argc, char** argv)
         rendererSwapBuffer(context.renderer);
 
         frameCount++;
-        end = clock();
-        frametimeSec = (double) (end - begin) / CLOCKS_PER_SEC;
+        TIMER_STOP(frametime);
         LOGI(
-            "Frametime: %lf s; FPS: %lf; Framecount: %zu\n", 
-            frametimeSec, 1 / frametimeSec, frameCount
+            "Frametime: %li us; FPS: %lf; Framecount: %zu\n", 
+            TIMER_REPORT_US(frametime, long), 1. / TIMER_REPORT_S(frametime, double),
+            frameCount
         );
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -152,6 +152,7 @@ int main(int argc, char** argv)
             .shader = fragmentShader
         }
     };
+    shaderProgramSetDefaultGeometryShader(&shaderProgram);
 
     size_t frameCount = 0;
     clock_t begin, end;

--- a/src/triangle.c
+++ b/src/triangle.c
@@ -1,24 +1,16 @@
 #include <assert.h>
 #include <math.h>
 #include <string.h>
-#include <wchar.h>
 #include "Context.h"
 #include "NDC.h"
 #include "triangle.h"
 #include "Shaders.h"
+#include "Vector/Vector2.h"
+#include "Vector/Vector3.h"
 #include "log.h"
+#include "utils.h"
 
 void drawTriangle(const GSOutput* restrict gsOutput, const ShaderProgram* restrict sp)
-{
-    triangleData data;
-    drawTrianglePreparation(gsOutput, sp, &data);
-    drawTriangleRasterization(gsOutput, &data, sp);
-}
-
-static void drawTrianglePreparation(
-    const GSOutput* restrict gsOutput, const ShaderProgram* restrict sp,
-    triangleData* restrict data
-)
 {
     VertexAttribute positionAttribute = sp->geometryShader.outputAttributes[
         sp->geometryShader.indexOfOutputPositionAttribute
@@ -38,178 +30,79 @@ static void drawTrianglePreparation(
     }
 
     Vector3d SSPositions[3], edgeVectors[3];
-    Vector2d maxBP;
-    Vector2i BBDimensions;
+    for (size_t i = 0; i < 3; i++)
+        SSPositions[i] = NDCToScreenSpace(context.renderer, NDCPositions[i]);
+    for (size_t i = 0; i < 3; i++)
+        edgeVectors[i] = Vector3dSubtract(
+            SSPositions[(i+1) % 3], SSPositions[i]
+        );
 
-    NDCToScreenSpaceArray(NDCPositions, SSPositions, 3);
-    getBoundingBoxArray(SSPositions, &data->minBP, &maxBP, &BBDimensions, 3);
-    calculateEdgeVectors(SSPositions, edgeVectors, 3);
-    calculatePositiveOnPlusYAndSlopeSignsArray(
-        SSPositions, edgeVectors, 
-        data->posOnPlusY, data->slopeSign, 3
-    );
+    Vector2d minBoundingPoint = {
+        MIN(SSPositions[0].x, MIN(SSPositions[1].x, SSPositions[2].x)),
+        MIN(SSPositions[0].y, MIN(SSPositions[1].y, SSPositions[2].y))
+    };
+    Vector2d maxBoundingPoint = {
+        MAX(SSPositions[0].x, MAX(SSPositions[1].x, SSPositions[2].x)),
+        MAX(SSPositions[0].y, MAX(SSPositions[1].y, SSPositions[2].y))
+    };
+
+    double barycentricCoordinates[3];
+    double barycentricDeltaX[3], barycentricDeltaY[3];
 
     calculateBarycentricCoordinatesForPointAndBarycentricDeltas(
-        SSPositions, edgeVectors, data->minBP, data->barycentricCoordinates, 
-        data->barycentricDeltaX, data->barycentricDeltaY
+        SSPositions, edgeVectors, minBoundingPoint, barycentricCoordinates,
+        barycentricDeltaX, barycentricDeltaY
     );
 
-    calculateTileDimensionsAndNTilesInBoundingBox(
-        BBDimensions, &data->tileDimensions, &data->nTilesInBox
-    );
-    calculateBarycentricTileDeltas(
-        data->tileDimensions, data->barycentricDeltaX, data->barycentricDeltaY,
-        data->barycentricTileDeltaX, data->barycentricTileDeltaY
-    );
-
-    for (uint8_t i = 0; i < 3; i++)
-        data->isEdgeNotFlatTopOrLeft[i] = \
-            !triangleIsEdgeFlatTopOrLeft(&edgeVectors[i]);
-}
-
-static void drawTriangleRasterization(
-    const GSOutput* restrict gsOutput, triangleData* restrict data,
-    const ShaderProgram* restrict sp
-)
-{
     double barycentricCoordinatesAtBeginningOfTheRow[3];
-    memcpy(
-        barycentricCoordinatesAtBeginningOfTheRow,
-        data->barycentricCoordinates,
-        sizeof(double) * 3
-    );
-
-    for (int yTile = 0; yTile < data->nTilesInBox.y; yTile++)
+    bool isEdgeNotFlatTopOrLeft[3];
+    for (uint8_t i = 0; i < 3; i++)
     {
-        for (int xTile = 0; xTile < data->nTilesInBox.x; xTile++)
+        barycentricCoordinatesAtBeginningOfTheRow[i] = barycentricCoordinates[i];
+        isEdgeNotFlatTopOrLeft[i] = !triangleIsEdgeFlatTopOrLeft(&edgeVectors[i]);
+    }
+
+    for (size_t y = minBoundingPoint.y; y < maxBoundingPoint.y; y += 1)
+    {
+        for (size_t x = minBoundingPoint.x; x < maxBoundingPoint.x; x += 1)
         {
-            Vector2d startPoint = {
-                data->minBP.x + xTile * data->tileDimensions.x,
-                data->minBP.y + yTile * data->tileDimensions.y
-            };
-            Vector2d endPoint = {
-                startPoint.x + data->tileDimensions.x,
-                startPoint.y + data->tileDimensions.y
-            };
-
-            bool rejected[3], accepted[3];
-            triangleRejectionAcceptionTests(data, rejected, accepted);
-
-            bool fullyAccepted = accepted[0] && accepted[1] && accepted[2];
-            bool fullyRejected = rejected[0] || rejected[1] || rejected[2];
-            bool check = !fullyAccepted;
-
-            if (fullyAccepted || !fullyRejected)
-                triangleLoopOverTileAndFill(
-                    check, &startPoint, &endPoint, data, sp, gsOutput
-                );
-
             for (uint8_t i = 0; i < 3; i++)
-                data->barycentricCoordinates[i] += data->barycentricTileDeltaX[i];
-        }
+            {
+                if (barycentricCoordinates[i] == 0 && isEdgeNotFlatTopOrLeft[i])
+                    goto nextPixel;
+            }
 
+            if (barycentricCoordinates[0] >= 0 && \
+                barycentricCoordinates[1] >= 0 && \
+                barycentricCoordinates[2] >= 0)
+            {
+                // TODO avoid VLA (custom allocator?)
+                uint8_t interpolatedBuffer[sp->geometryShader.nBytesPerOutputVertex];
+                Interpolated* pInterpolated = (Interpolated*) interpolatedBuffer;
+                triangleInterpolateGsOutput(
+                    gsOutput, barycentricCoordinates, sp, pInterpolated
+                );
+                double depth = ((double*) (
+                    (uint8_t*) pInterpolated + sp->geometryShader.outputAttributes[
+                        sp->geometryShader.indexOfOutputPositionAttribute
+                    ].offsetBytes
+                ))[2];
+
+                Color color;
+                sp->fragmentShader.shader(sp, pInterpolated, &color);
+
+                rendererDrawPixel(context.renderer, (Vector2i) {x, y}, depth, color);
+            }
+
+nextPixel:
+            for (uint8_t i = 0; i < 3; i++)
+                barycentricCoordinates[i] += barycentricDeltaX[i];
+        }
         for (uint8_t i = 0; i < 3; i++)
-            barycentricCoordinatesAtBeginningOfTheRow[i] += \
-                data->barycentricTileDeltaY[i];
-
-        memcpy(
-            data->barycentricCoordinates,
-            barycentricCoordinatesAtBeginningOfTheRow,
-            sizeof(double) * 3
-        );
-    }
-}
-
-static void NDCToScreenSpaceArray(
-    const Vector3d* restrict NDCPositions, Vector3d* restrict SSPositions,
-    const size_t n
-)
-{
-    for (size_t i = 0; i < n; i++)
-        SSPositions[i] = NDCToScreenSpace(context.renderer, NDCPositions[i]);
-}
-
-static void getBoundingBoxArray(
-    const Vector3d* restrict SSPositions, Vector2d* restrict min,
-    Vector2d* restrict max, Vector2i* restrict BBDimensions, const size_t n
-)
-{
-    double xmin = SSPositions[0].x, xmax = SSPositions[0].x;
-    double ymin = SSPositions[0].y, ymax = SSPositions[0].y;
-
-    for (size_t i = 0; i < n; i++)
-    {
-        double x = SSPositions[i].x;
-        double y = SSPositions[i].y;
-
-        if (x < xmin)
-            xmin = x;
-        else if (x > xmax)
-            xmax = x;
-        if (y < ymin)
-            ymin = y;
-        else if (y > ymax)
-            ymax = y;
-    }
-
-    *min = (Vector2d) {xmin, ymin};
-    *max = (Vector2d) {xmax, ymax};
-    *BBDimensions = (Vector2i) {
-        xmax - xmin,
-        ymax - ymin,
-    };
-}
-
-static void calculateEdgeVectors(
-    const Vector3d* restrict SSPositions, Vector3d* restrict edgeVectors,
-    const size_t n
-)
-{
-    for (size_t i = 0; i < n; i++)
-    {
-        edgeVectors[i] = Vector3dSubtract(
-            SSPositions[(i+1) % n], SSPositions[i]
-        );
-    }
-}
-
-static void calculatePositiveOnPlusYAndSlopeSignsArray(
-    const Vector3d* restrict SSPositions, const Vector3d* restrict edgeVectors,
-    bool* restrict posOnPlusY, bool* restrict slopeSigns, const size_t n
-)
-{
-    for (uint8_t iEdge = 0; iEdge < n; iEdge++)
-    {
-        uint8_t iFirstVertexOnEdge = iEdge;
-        uint8_t iSecondVertexOnEdge = (iFirstVertexOnEdge + 1) % n;
-        uint8_t iThirdVertex = (iFirstVertexOnEdge + 2) % n;
-
-        double dx = SSPositions[iFirstVertexOnEdge].x - \
-                    SSPositions[iSecondVertexOnEdge].x;
-        double dy = SSPositions[iFirstVertexOnEdge].y - \
-                    SSPositions[iSecondVertexOnEdge].y;
-        double F = \
-            SSPositions[iThirdVertex].x * dy - SSPositions[iThirdVertex].y * dx + \
-            SSPositions[iFirstVertexOnEdge].y * dx - SSPositions[iFirstVertexOnEdge].x * dy;
-        assert(F != 0 && "The triangle is degenerate");
-
-        if (dx > 0)
         {
-            if (F < 0)
-                posOnPlusY[iEdge] = true;
-            else
-                posOnPlusY[iEdge] = false;
+            barycentricCoordinatesAtBeginningOfTheRow[i] += barycentricDeltaY[i];
+            barycentricCoordinates[i] = barycentricCoordinatesAtBeginningOfTheRow[i];
         }
-        else
-        {
-            if (F < 0)
-                posOnPlusY[iEdge] = false;
-            else
-                posOnPlusY[iEdge] = true;
-        }
-
-        double slope = edgeVectors[iEdge].y / edgeVectors[iEdge].x;
-        slopeSigns[iEdge] = slope >= 0;
     }
 }
 
@@ -257,199 +150,9 @@ static void calculateBarycentricCoordinatesForPointAndBarycentricDeltas(
     barycentricDeltaY[2] = edgeVectors[0].x / areaX2;
 }
 
-static void calculateTileDimensionsAndNTilesInBoundingBox(
-    const Vector2i BBDimensions, Vector2i* restrict tileDimensions,
-    Vector2i* restrict nTiles
-)
-{
-    // linear regression (boundingBoxDimension -> tileDimension)
-    const double coefficient = 0.021;
-    const double intercept = 14.87;
-    *tileDimensions = (Vector2i) {
-        round(coefficient * BBDimensions.x + intercept),
-        round(coefficient * BBDimensions.y + intercept)
-    };
-    *nTiles = (Vector2i) {
-        ceil((double) BBDimensions.x / tileDimensions->x),
-        ceil((double) BBDimensions.y / tileDimensions->y)
-    };
-}
-
-static void calculateBarycentricTileDeltas(
-    const Vector2i tileDimensions, const double* restrict barycentricDeltaX,
-    const double* restrict barycentricDeltaY, double* restrict barycentricTileDeltaX,
-    double* restrict barycentricTileDeltaY
-)
-{
-    barycentricTileDeltaX[0] = barycentricDeltaX[0] * tileDimensions.x;
-    barycentricTileDeltaX[1] = barycentricDeltaX[1] * tileDimensions.x;
-    barycentricTileDeltaX[2] = barycentricDeltaX[2] * tileDimensions.x;
-
-    barycentricTileDeltaY[0] = barycentricDeltaY[0] * tileDimensions.y;
-    barycentricTileDeltaY[1] = barycentricDeltaY[1] * tileDimensions.y;
-    barycentricTileDeltaY[2] = barycentricDeltaY[2] * tileDimensions.y;
-}
-
 static bool triangleIsEdgeFlatTopOrLeft(const Vector3d* restrict edgeVector)
 {
     return ((edgeVector->x > 0) && (edgeVector->y == 0)) || (edgeVector->y < 0);
-}
-
-static void triangleRejectionAcceptionTests(
-    const triangleData* restrict data, bool* restrict rejected,
-    bool* restrict accepted
-)
-{
-    for (uint8_t iEdge = 0; iEdge < 3; iEdge++)
-    {
-        // barycentric coordinates for acception and rejection points
-        double barycentricAcception, barycentricRejection;
-        uint8_t iBarycentric = (iEdge + 2) % 3;
-        if (data->posOnPlusY[iEdge])
-        {
-            if (data->slopeSign[iEdge])
-            {
-                barycentricAcception = \
-                    data->barycentricCoordinates[iBarycentric] + \
-                    data->barycentricTileDeltaX[iBarycentric];
-                barycentricRejection = \
-                    data->barycentricCoordinates[iBarycentric] + \
-                    data->barycentricTileDeltaY[iBarycentric];
-            }
-            else  // negative slope
-            {
-                barycentricAcception = \
-                    data->barycentricCoordinates[iBarycentric];
-                barycentricRejection = \
-                    data->barycentricCoordinates[iBarycentric] + \
-                    data->barycentricTileDeltaX[iBarycentric] + \
-                    data->barycentricTileDeltaY[iBarycentric];
-            }
-        }
-        else  // negative on +y
-        {
-            if (data->slopeSign[iEdge])
-            {
-                barycentricAcception = \
-                    data->barycentricCoordinates[iBarycentric] + \
-                    data->barycentricTileDeltaY[iBarycentric];
-                barycentricRejection = \
-                    data->barycentricCoordinates[iBarycentric] + \
-                    data->barycentricTileDeltaX[iBarycentric];
-            }
-            else  // negative slope
-            {
-                barycentricAcception = \
-                    data->barycentricCoordinates[iBarycentric] + \
-                    data->barycentricTileDeltaX[iBarycentric] + \
-                    data->barycentricTileDeltaY[iBarycentric];
-                barycentricRejection = \
-                    data->barycentricCoordinates[iBarycentric];
-            }
-        }
-
-        if (barycentricAcception > 0)
-        {
-            accepted[iEdge] = true;
-            rejected[iEdge] = false;
-        }
-        else if (barycentricRejection <= 0)
-        {
-            accepted[iEdge] = false;
-            rejected[iEdge] = true;
-        }
-        else  // TODO how tile can be neither accepted nor rejected?
-        {
-            accepted[iEdge] = false;
-            rejected[iEdge] = false;
-        }
-    }
-}
-
-static void triangleLoopOverTileAndFill(
-    const bool check, const Vector2d* restrict startPoint,
-    const Vector2d* restrict endPoint, triangleData* restrict data,
-    const ShaderProgram* restrict sp, const void* restrict gsOutput
-)
-{
-    double barycentricCoordinatesAtBeginningOfTheRow[3];
-    memcpy(
-        data->barycentricCoordinatesCopy,
-        data->barycentricCoordinates,
-        sizeof(double) * 3
-    );
-    memcpy(
-        barycentricCoordinatesAtBeginningOfTheRow,
-        data->barycentricCoordinatesCopy,
-        sizeof(double) * 3
-    );
-
-    for (size_t y = startPoint->y; y < endPoint->y; y += 1)
-    {
-        for (size_t x = startPoint->x; x < endPoint->x; x += 1)
-        {
-            if (check)
-            {
-                // If current point lies on the edge that is not flat top or 
-                // left, do not draw the point (rasterization rules)
-                for (uint8_t i = 0; i < 3; i++)
-                    if (data->barycentricCoordinatesCopy[i] == 0 && \
-                        data->isEdgeNotFlatTopOrLeft[i])
-                        goto nextPixel;
-
-                if (data->barycentricCoordinatesCopy[0] < 0 || \
-                    data->barycentricCoordinatesCopy[1] < 0 || \
-                    data->barycentricCoordinatesCopy[2] < 0)
-                    goto nextPixel;
-            }
-
-            Color color;
-            double depth;
-            {
-                // TODO avoid VLA (custom allocator?)
-                uint8_t interpolatedBuffer[sp->geometryShader.nBytesPerOutputVertex];
-                Interpolated* pInterpolated = (Interpolated*) interpolatedBuffer;
-                triangleInterpolateGsOutput(
-                    gsOutput, data->barycentricCoordinatesCopy, sp, pInterpolated
-                );
-                depth = ((double*) (
-                    (uint8_t*) pInterpolated + sp->geometryShader.outputAttributes[
-                        sp->geometryShader.indexOfOutputPositionAttribute
-                    ].offsetBytes
-                ))[2];
-
-#ifndef NDEBUG
-                if (context.debug.colorRasterizerTiles)
-                {
-                    if (check)
-                        color = (Color) {255, 0, 0, 255};
-                    else
-                        color = (Color) {0, 255, 0, 255};
-                }
-                else
-#endif
-                {
-                    sp->fragmentShader.shader(sp, pInterpolated, &color);
-                }
-            }
-
-            rendererDrawPixel(context.renderer, (Vector2i) {x, y}, depth, color);
-
-nextPixel:
-            for (uint8_t i = 0; i < 3; i++)
-                data->barycentricCoordinatesCopy[i] += data->barycentricDeltaX[i];
-        }
-
-        for (uint8_t i = 0; i < 3; i++)
-            barycentricCoordinatesAtBeginningOfTheRow[i] += \
-                data->barycentricDeltaY[i];
-
-        memcpy(
-            data->barycentricCoordinatesCopy,
-            barycentricCoordinatesAtBeginningOfTheRow,
-            sizeof(double) * 3
-        );
-    }
 }
 
 // @brief Interpolates geometry shader output in triangle
@@ -464,12 +167,13 @@ static void triangleInterpolateGsOutput(
     // (                           V0                            )  (       V1      ) (       V2      )
     // (          A0V0          )      (           AnV0          )  (A0V1, ..., AnV1) (A0V2, ..., AnV2)
     // V0A0E0, V0A0E1, ... V0A0En, ... V0AnE0, V0AnE1, ..., V0AnEn, ...
+    // [V]ertex, [A]ttribute, [E]lement
 
+    const GeometryShader* gs = &sp->geometryShader;
     // points to the beginning of attribute
     const void* pAttrVoid = gsOutput;
     // points to attribute in output buffer
     void* pInterpolatedAttrVoid = pInterpolatedBuffer;
-    const GeometryShader* gs = &sp->geometryShader;
 
     for (size_t attrI = 0; attrI < gs->nOutputAttributes; attrI++)
     {

--- a/src/triangle.h
+++ b/src/triangle.h
@@ -6,48 +6,14 @@
 typedef struct
 {
     double barycentricCoordinates[3];
-    double barycentricCoordinatesCopy[3];
     double barycentricDeltaX[3];
     double barycentricDeltaY[3];
-    double barycentricTileDeltaX[3];
-    double barycentricTileDeltaY[3];
-
-    bool posOnPlusY[3];
-    bool slopeSign[3];
     bool isEdgeNotFlatTopOrLeft[3];
-
-    Vector2i tileDimensions;
-    Vector2i nTilesInBox;
-    Vector2d minBP;
+    Vector2d minBP, maxBP;
 } triangleData;
 
 void drawTriangle(const GSOutput* restrict gsOutput, const ShaderProgram* restrict sp);
 
-static void drawTrianglePreparation(
-    const GSOutput* restrict gsOutput, const ShaderProgram* restrict sp,
-    triangleData* restrict data
-);
-static void drawTriangleRasterization(
-    const GSOutput* restrict gsOutput, triangleData* restrict data,
-    const ShaderProgram* restrict sp
-);
-
-static void NDCToScreenSpaceArray(
-    const Vector3d* restrict NDCPositions, Vector3d* restrict SSPositions,
-    const size_t n
-);
-static void getBoundingBoxArray(
-    const Vector3d* restrict SSPositions, Vector2d* restrict min,
-    Vector2d* restrict max, Vector2i* restrict BBDimensions, const size_t n
-);
-static void calculateEdgeVectors(
-    const Vector3d* restrict SSPositions, Vector3d* restrict edgeVectors,
-    const size_t n
-);
-static void calculatePositiveOnPlusYAndSlopeSignsArray(
-    const Vector3d* restrict SSPositions, const Vector3d* restrict edgeVectors,
-    bool* restrict posOnPlusY, bool* restrict slopeSigns, const size_t n
-);
 static double signedAreaParallelogram(
     const Vector3d* restrict a, const Vector3d* restrict b
 );
@@ -56,26 +22,7 @@ static void calculateBarycentricCoordinatesForPointAndBarycentricDeltas(
     const Vector2d point, double* restrict barycentricCoordinates,
     double* restrict barycentricDeltaX, double* restrict barycentricDeltaY
 );
-static void calculateTileDimensionsAndNTilesInBoundingBox(
-    const Vector2i BBDimensions, Vector2i* restrict tileDimensions,
-    Vector2i* restrict nTiles
-);
-static void calculateBarycentricTileDeltas(
-    const Vector2i tileDimensions, const double* restrict barycentricDeltaX,
-    const double* restrict barycentricDeltaY, double* restrict barycentricTileDeltaX,
-    double* restrict barycentricTileDeltaY
-);
 static bool triangleIsEdgeFlatTopOrLeft(const Vector3d* restrict edgeVector);
-
-static void triangleRejectionAcceptionTests(
-    const triangleData* restrict data, bool* restrict rejected,
-    bool* restrict accepted
-);
-static void triangleLoopOverTileAndFill(
-    const bool check, const Vector2d* restrict startPoint,
-    const Vector2d* restrict endPoint, triangleData* restrict data,
-    const ShaderProgram* restrict sp, const void* restrict gsOutput
-);
 
 static void triangleInterpolateGsOutput(
     const void* gsOutput, const double barycentricCoordinates[3],

--- a/src/triangle.h
+++ b/src/triangle.h
@@ -67,7 +67,7 @@ static void triangleLoopOverTileAndFill(
 );
 
 static void triangleInterpolateGsOutput(
-    void* gsOutput, double* barycentricCoordinates, ShaderProgram* sp,
-    void* interpolated
+    const void* gsOutput, const double barycentricCoordinates[3],
+    const ShaderProgram* sp, void* pInterpolatedBuffer
 );
 

--- a/src/triangle.h
+++ b/src/triangle.h
@@ -21,14 +21,14 @@ typedef struct
     Vector2d minBP;
 } triangleData;
 
-void drawTriangle(const void* restrict gsOutput, const ShaderProgram* restrict sp);
+void drawTriangle(const GSOutput* restrict gsOutput, const ShaderProgram* restrict sp);
 
 static void drawTrianglePreparation(
-    const void* restrict gsOutput, const ShaderProgram* restrict sp,
+    const GSOutput* restrict gsOutput, const ShaderProgram* restrict sp,
     triangleData* restrict data
 );
 static void drawTriangleRasterization(
-    const void* restrict gsOutput, triangleData* restrict data,
+    const GSOutput* restrict gsOutput, triangleData* restrict data,
     const ShaderProgram* restrict sp
 );
 
@@ -79,6 +79,6 @@ static void triangleLoopOverTileAndFill(
 
 static void triangleInterpolateGsOutput(
     const void* gsOutput, const double barycentricCoordinates[3],
-    const ShaderProgram* restrict sp, void* pInterpolatedBuffer
+    const ShaderProgram* restrict sp, Interpolated* pInterpolatedBuffer
 );
 

--- a/src/triangle.h
+++ b/src/triangle.h
@@ -21,53 +21,64 @@ typedef struct
     Vector2d minBP;
 } triangleData;
 
-void drawTriangle(void* gsOutput, ShaderProgram* sp);
+void drawTriangle(const void* restrict gsOutput, const ShaderProgram* restrict sp);
 
 static void drawTrianglePreparation(
-    void* gsOutput, ShaderProgram* sp, triangleData* returnData
+    const void* restrict gsOutput, const ShaderProgram* restrict sp,
+    triangleData* restrict data
 );
 static void drawTriangleRasterization(
-    void* gsOutput, triangleData* data, ShaderProgram* sp
+    const void* restrict gsOutput, triangleData* restrict data,
+    const ShaderProgram* restrict sp
 );
 
 static void NDCToScreenSpaceArray(
-    Vector3d* NDCPositions, Vector3d* SSPositions, size_t n
+    const Vector3d* restrict NDCPositions, Vector3d* restrict SSPositions,
+    const size_t n
 );
 static void getBoundingBoxArray(
-    Vector3d* SSPositions, Vector2d* min, Vector2d* max,
-    Vector2i* BBDimensions, size_t n
+    const Vector3d* restrict SSPositions, Vector2d* restrict min,
+    Vector2d* restrict max, Vector2i* restrict BBDimensions, const size_t n
 );
 static void calculateEdgeVectors(
-    Vector3d* SSPositions, Vector3d* edgeVectors, size_t n
+    const Vector3d* restrict SSPositions, Vector3d* restrict edgeVectors,
+    const size_t n
 );
 static void calculatePositiveOnPlusYAndSlopeSignsArray(
-    Vector3d* SSPositions, Vector3d* edgeVectors,
-    bool* posOnPlusY, bool* slopeSigns, size_t n
+    const Vector3d* restrict SSPositions, const Vector3d* restrict edgeVectors,
+    bool* restrict posOnPlusY, bool* restrict slopeSigns, const size_t n
+);
+static double signedAreaParallelogram(
+    const Vector3d* restrict a, const Vector3d* restrict b
 );
 static void calculateBarycentricCoordinatesForPointAndBarycentricDeltas(
-    Vector3d* SSPositions, Vector3d* edgeVectors, Vector2d point,
-    double* barycentricCoordinates, double* barycentricDeltaX, 
-    double* barycentricDeltaY
+    const Vector3d* restrict SSPositions, const Vector3d* restrict edgeVectors,
+    const Vector2d point, double* restrict barycentricCoordinates,
+    double* restrict barycentricDeltaX, double* restrict barycentricDeltaY
 );
 static void calculateTileDimensionsAndNTilesInBoundingBox(
-    Vector2i BBDimensions, Vector2i* tileDimensions, Vector2i* NTiles
+    const Vector2i BBDimensions, Vector2i* restrict tileDimensions,
+    Vector2i* restrict nTiles
 );
 static void calculateBarycentricTileDeltas(
-    Vector2i tileDimensions, double* barycentricDeltaX, double* barycentricDeltaY,
-    double* barycentricTileDeltaX, double* barycentricTileDeltaY
+    const Vector2i tileDimensions, const double* restrict barycentricDeltaX,
+    const double* restrict barycentricDeltaY, double* restrict barycentricTileDeltaX,
+    double* restrict barycentricTileDeltaY
 );
-static bool triangleIsEdgeFlatTopOrLeft(Vector3d edgeVector);
+static bool triangleIsEdgeFlatTopOrLeft(const Vector3d* restrict edgeVector);
 
 static void triangleRejectionAcceptionTests(
-    triangleData* data, bool* rejected, bool* accepted
+    const triangleData* restrict data, bool* restrict rejected,
+    bool* restrict accepted
 );
 static void triangleLoopOverTileAndFill(
-    bool check, Vector2d startPoint, Vector2d endPoint, triangleData* data,
-    ShaderProgram* sp, void* gsOutput
+    const bool check, const Vector2d* restrict startPoint,
+    const Vector2d* restrict endPoint, triangleData* restrict data,
+    const ShaderProgram* restrict sp, const void* restrict gsOutput
 );
 
 static void triangleInterpolateGsOutput(
     const void* gsOutput, const double barycentricCoordinates[3],
-    const ShaderProgram* sp, void* pInterpolatedBuffer
+    const ShaderProgram* restrict sp, void* pInterpolatedBuffer
 );
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -22,6 +22,9 @@
     #define M_PI 3.14159265358979323846
 #endif
 
+#define MIN(a, b) ( (a) < (b) ? (a) : (b) )
+#define MAX(a, b) ( (a) > (b) ? (a) : (b) )
+
 #define RADIANS(x) ((M_PI / 180) * (x))
 #define ROUGHLY_EQUAL(a, b) \
     (fabs((a) - (b)) < TOLERANCE)


### PR DESCRIPTION
Finishing touches (I hope so) of these 5-month long tries to optimize triangle rasterization...
- **Go back to simple, untiled rasterizer**
  - The unreadable and unmantainable code is not worth it to get miserable performance boost
- Rewrite `triangleInterpolateGsOutput` to make it faster
- Add a function to set default geometry shader to avoid unreadable ternary operator clutter in drawing code (`shaderProgramSetDefaultGeometryShader`)
- Add convenient timer macros with reasonable precision to make timing easier
- Add several empty types to avoid overusing `void*` in drawing code and introduce at least some kind of type safety (i.e. `Vertex`, `GSOutput`, `Interpolated`)
- Fix a possible memory error in `VertexBuffer` constructor